### PR TITLE
Add scale factor + apply view with fill

### DIFF
--- a/src/MSeven/MSevenAeSurfaceBlElement3.class.st
+++ b/src/MSeven/MSevenAeSurfaceBlElement3.class.st
@@ -6,7 +6,9 @@ Class {
 		'cameraSurface',
 		'cameraResolution',
 		'cameraAngle',
-		'cameraPosition'
+		'cameraPosition',
+		'pattern',
+		'scaleFactor'
 	],
 	#category : #'MSeven-POC'
 }
@@ -17,8 +19,9 @@ MSevenAeSurfaceBlElement3 >> aeDrawGeometryOn: aeCanvas [
 
 	self refreshCameraSurface.
 	aeCanvas privateAeCairoContext
-		sourceSurface: cameraSurface x: 0.0 y: 0.0;
-		paint
+		source: pattern;
+		rectangleTo: self size;
+		fill
 ]
 
 { #category : #accessing }
@@ -30,6 +33,14 @@ MSevenAeSurfaceBlElement3 >> cameraPosition: aPoint cameraAngle: aNumber [
 ]
 
 { #category : #initialization }
+MSevenAeSurfaceBlElement3 >> initialize [
+
+	super initialize.
+	
+	scaleFactor := 1.0
+]
+
+{ #category : #accessing }
 MSevenAeSurfaceBlElement3 >> map: aForm cameraResolution: aPoint [
 
 	map := aForm.
@@ -42,7 +53,17 @@ MSevenAeSurfaceBlElement3 >> map: aForm cameraResolution: aPoint [
 			format: AeCairoSurfaceFormat argb32.
 	cameraSurface newContext
 		sourceColor: Color black;
-		paint
+		paint.
+
+	pattern := AeCairoSurfacePattern surface: cameraSurface.
+	pattern filter: AeCairoSamplingFilter nearest.
+	
+	"By default, patterns have the identity matrix.
+	Then, we will only change it if really needed."
+	(scaleFactor closeTo: 1.0) ifFalse: [
+		pattern matrix: (AeCairoMatrix
+			newScalingByX: 1.0 / scaleFactor
+			            y: 1.0 / scaleFactor) ]
 ]
 
 { #category : #initialization }
@@ -95,4 +116,10 @@ MSevenAeSurfaceBlElement3 >> refreshCameraSurface [
 				put: floorColor asPremultipliedARGB32Integer ] ].
 
 	cameraSurface markDirty
+]
+
+{ #category : #accessing }
+MSevenAeSurfaceBlElement3 >> scaleFactor: aFloat [
+
+	scaleFactor := aFloat
 ]


### PR DESCRIPTION
Fixes #5.
Fixes #6.

Try with:

```smalltalk

	viewResolution := 256 @ 240.
	scaleFactor := 3.0.
	viewMargin := 5.
	viewSize := 200 @ (viewResolution y * scaleFactor).
	
	view := MSevenAeSurfaceBlElement3 new.
	view scaleFactor: scaleFactor.
	view size: viewSize.
	view position: viewMargin asPoint.
	view
		map: MSevenResources checkerboardTexture
		cameraResolution: viewResolution.

	space := view openInNewSpaceWithPyramidShortcut.
	space extent: (viewResolution * scaleFactor) + (viewMargin * 2) asPoint.
	space title: ('POC3 scaleFactor={1}, viewSize={2}' format: {scaleFactor. viewSize}).


	position := 0@0.
	view enqueueTask:
		(BlNumberTransition new
			from: 0; to: 1;
			onStepDo: [ :t |
				position := position + (0.01 @ 0).
				angle := (position x * 0.3) sin.
				view
					cameraPosition: position
					cameraAngle: angle ];
			beInfinite;
			yourself)
```

<img width="890" alt="Screenshot 2023-10-17 at 18 09 37" src="https://github.com/labordep/M-Seven/assets/3044265/f26203d5-bf45-42fd-9c06-abc0c42aa1ee">
